### PR TITLE
GH#1: Bugfix marcdump to print warnings

### DIFF
--- a/marc-record/bin/marcdump
+++ b/marc-record/bin/marcdump
@@ -84,9 +84,9 @@ for my $filename ( @files ) {
             }
         }
 
-        if ( $marc->warnings() ) {
+        if ( my @warnings = $marc->warnings() ) {
             ++$errors{$filename};
-            print join( "\n", $marc->warnings(), "" );
+            print join( "\n", @warnings, "" );
         }
     } # while
     $file->close();


### PR DESCRIPTION
Save $marc->warnings() into a variable to print them out later.
