### PR TITLE
Usmarc record terminator

### DIFF
--- a/marc-record/lib/MARC/File/USMARC.pm
+++ b/marc-record/lib/MARC/File/USMARC.pm
@@ -64,7 +64,7 @@ sub _next {
             $self->{buffer} = <$fh>;
             # This is an attempt at detecting a leader
             last if ($self->{buffer} =~ /^[ \x00\x0a\x0d\x1a]*[0-9]{5}[acdnposx][acdefgijkmoprtz]...22/);
-            $usmarc = join($usmarc, END_OF_RECORD, $self->{buffer});
+            $usmarc .= $self->{buffer};
         }
     };
 

--- a/marc-record/lib/MARC/File/USMARC.pm
+++ b/marc-record/lib/MARC/File/USMARC.pm
@@ -71,6 +71,9 @@ sub _next {
     # remove illegal garbage that sometimes occurs between records
     $usmarc =~ s/^[ \x00\x0a\x0d\x1a]+//;
 
+    # In case we picked up some of that garbage, remove it from the *end* of the record too
+    $usmarc =~ s/\x1d[ \x00\x0a\x0d\x1a]+$/\x1d/;
+
     return $usmarc;
 }
 


### PR DESCRIPTION
This is an attempt to fix issues with the record terminator in USMARC also being a pretty quote character present in some descriptions, meaning that the resulting record ends up split into a truncated record and a junk record. I have attached an example file, trimmed from an OCLC export, only including the record before, record with the terminator within it, and the record after.

[onebadrecord.zip](https://github.com/perl4lib/marc-perl/files/409526/onebadrecord.zip)
