### PR TITLE
fix parsing of external XML entitities

### DIFF
--- a/marc-xml/lib/MARC/File/XML.pm
+++ b/marc-xml/lib/MARC/File/XML.pm
@@ -414,6 +414,7 @@ sub _next {
 
 sub _parser {
     $parser ||= XML::LibXML->new(
+        expand_entities => 1,
         ext_ent_handler => sub {
             die "External entities are not supported\n";
         }


### PR DESCRIPTION
See https://rt.cpan.org/Public/Bug/Display.html?id=131495 and failures for recent Perl version http://matrix.cpantesters.org/?dist=MARC-File-XML+1.0.5

Looks like you have to set LibXML [parser option](https://metacpan.org/dist/XML-LibXML/view/lib/XML/LibXML/Parser.pod#PARSER-OPTIONS) `expand_entities` manually.  