### PR TITLE
Declare LICENSE in marc-lint and marc-marcmaker Makefile.PL

### DIFF
--- a/marc-lint/Makefile.PL
+++ b/marc-lint/Makefile.PL
@@ -7,6 +7,7 @@ use ExtUtils::MakeMaker;
     VERSION_FROM  => 'lib/MARC/Lint.pm',
     ABSTRACT_FROM => 'lib/MARC/Lint.pm',
     AUTHOR        => 'Bryan Baldus <eijabb@cpan.org>',
+    LICENSE       => 'perl',
     PREREQ_PM     => {
                         'Test::More' => 0,
                         'MARC::Record' => 0,

--- a/marc-marcmaker/Makefile.PL
+++ b/marc-marcmaker/Makefile.PL
@@ -6,6 +6,7 @@ use ExtUtils::MakeMaker;
     DISTNAME      => 'MARC-File-MARCMaker',
     VERSION_FROM  => 'lib/MARC/File/MARCMaker.pm',
     AUTHOR        => 'Bryan Baldus <eijabb@cpan.org>',
+    LICENSE       => 'perl',
     PREREQ_PM     => {
                         'Test::More' => 0,
                         'MARC::Record' => 0,


### PR DESCRIPTION
Both `marc-lint/Makefile.PL` and `marc-marcmaker/Makefile.PL` omitted the `LICENSE` key from `WriteMakefile()`, so the generated META has no license field for either distribution. On MetaCPAN this renders as license "Unknown" for both `MARC::Lint` and `MARC::File::MARCMaker`, even though both READMEs state:

> This software is free software and may be distributed under the same terms as Perl itself.

The other four distributions in this repo (`marc-record`, `marc-xml`, `marc-charset`) already set `LICENSE => 'perl'`; this brings the remaining two in line.

Verified `perl Makefile.PL` regenerates a `MYMETA.yml` with `license: perl` for both distributions after this change.

Fixes #15