### PR TITLE
Declare repository and bugtracker resources in all 6 distributions

### DIFF
--- a/marc-charset/Makefile.PL
+++ b/marc-charset/Makefile.PL
@@ -14,6 +14,19 @@ WriteMakefile(
                             'Galen Charlton <gmcharlt@gmail.com>',
                        ],
     LICENSE         => 'perl',
+    META_MERGE      => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/perl4lib/marc-perl.git',
+                web  => 'https://github.com/perl4lib/marc-perl/tree/master/marc-charset',
+            },
+            bugtracker => {
+                web => 'https://github.com/perl4lib/marc-perl/issues',
+            },
+        },
+    },
     PMLIBDIRS       => ['lib'],
     PREREQ_PM       => {
                             'Test::More'            => 0, 

--- a/marc-lint/Makefile.PL
+++ b/marc-lint/Makefile.PL
@@ -7,6 +7,19 @@ use ExtUtils::MakeMaker;
     VERSION_FROM  => 'lib/MARC/Lint.pm',
     ABSTRACT_FROM => 'lib/MARC/Lint.pm',
     AUTHOR        => 'Bryan Baldus <eijabb@cpan.org>',
+    META_MERGE    => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/perl4lib/marc-perl.git',
+                web  => 'https://github.com/perl4lib/marc-perl/tree/master/marc-lint',
+            },
+            bugtracker => {
+                web => 'https://github.com/perl4lib/marc-perl/issues',
+            },
+        },
+    },
     PREREQ_PM     => {
                         'Test::More' => 0,
                         'MARC::Record' => 0,

--- a/marc-marcmaker/Makefile.PL
+++ b/marc-marcmaker/Makefile.PL
@@ -6,6 +6,19 @@ use ExtUtils::MakeMaker;
     DISTNAME      => 'MARC-File-MARCMaker',
     VERSION_FROM  => 'lib/MARC/File/MARCMaker.pm',
     AUTHOR        => 'Bryan Baldus <eijabb@cpan.org>',
+    META_MERGE    => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/perl4lib/marc-perl.git',
+                web  => 'https://github.com/perl4lib/marc-perl/tree/master/marc-marcmaker',
+            },
+            bugtracker => {
+                web => 'https://github.com/perl4lib/marc-perl/issues',
+            },
+        },
+    },
     PREREQ_PM     => {
                         'Test::More' => 0,
                         'MARC::Record' => 0,

--- a/marc-mij/Build.PL
+++ b/marc-mij/Build.PL
@@ -9,6 +9,19 @@ my $builder = Module::Build->new(
     dist_author         => q{Bill Dueber <dueberb@umich.edu>},
     dist_version_from   => 'lib/MARC/File/MiJ.pm',
     release_status      => 'stable',
+    meta_merge          => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/perl4lib/marc-perl.git',
+                web  => 'https://github.com/perl4lib/marc-perl/tree/master/marc-mij',
+            },
+            bugtracker => {
+                web => 'https://github.com/perl4lib/marc-perl/issues',
+            },
+        },
+    },
     configure_requires => {
         'Module::Build' => 0,
     },

--- a/marc-record/Makefile.PL
+++ b/marc-record/Makefile.PL
@@ -11,6 +11,19 @@ use ExtUtils::MakeMaker;
     PMLIBDIRS       => [ qw( lib/ ) ],
     AUTHOR          => 'Galen Charlton <gmcharlt@gmail.com>',
     LICENSE         => 'perl',
+    META_MERGE      => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/perl4lib/marc-perl.git',
+                web  => 'https://github.com/perl4lib/marc-perl/tree/master/marc-record',
+            },
+            bugtracker => {
+                web => 'https://github.com/perl4lib/marc-perl/issues',
+            },
+        },
+    },
     PREREQ_PM       => {
         'Test::More' => 0,
         'File::Spec' => 0,

--- a/marc-xml/Makefile.PL
+++ b/marc-xml/Makefile.PL
@@ -13,6 +13,19 @@ WriteMakefile(
                             'Galen Charlton <gmcharlt@gmail.com>',
                        ],
     'LICENSE'       => 'perl',
+    'META_MERGE'    => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/perl4lib/marc-perl.git',
+                web  => 'https://github.com/perl4lib/marc-perl/tree/master/marc-xml',
+            },
+            bugtracker => {
+                web => 'https://github.com/perl4lib/marc-perl/issues',
+            },
+        },
+    },
     'PREREQ_PM'     => {
                             'XML::LibXML'   => 1.66,
                             'MARC::Record'  => 2.0,


### PR DESCRIPTION
None of the distributions in this repo (`marc-record`, `marc-lint`, `marc-xml`, `marc-mij`, `marc-marcmaker`, `marc-charset`) declared `resources.repository` / `resources.bugtracker` in their build metadata, so every MetaCPAN page in the family shows no GitHub link and no issue-tracker link in the sidebar.

This adds `META_MERGE` (and `meta_merge` for `marc-mij`'s `Module::Build`-based `Build.PL`) to all six, pointing:

- `resources.repository.url` at this repo's git URL
- `resources.repository.web` at each distribution's own subdirectory (e.g. `.../tree/master/marc-record`)
- `resources.bugtracker.web` at this repo's issue tracker

Verified `perl Makefile.PL` / `perl Build.PL` regenerates a `MYMETA.json` with the expected `resources` block for all six distributions.

Fixes #16