### PR TITLE
Make decode() lenient for empty datafields and missing indicators

### DIFF
--- a/marc-xml/Changes
+++ b/marc-xml/Changes
@@ -1,5 +1,20 @@
 Revision history for Perl extension MARC-XML
 
+1.1.0
+       - decode() no longer dies on a <datafield> with no <subfield>
+         children, or one missing its ind1/ind2 attributes entirely.
+         Both are now treated the way MARC::File::USMARC already
+         treats their binary equivalents: the field is dropped (or
+         its indicators default to blank), a warning is recorded via
+         $record->_warn(), and the rest of the record is still
+         returned instead of the whole parse failing.
+
+         This is a behavior change: code that relied on
+         new_from_xml() throwing to detect these two specific cases
+         needs to check $record->warnings() after a successful parse
+         instead. Document-level errors (no <record> element at all)
+         are unaffected and still die as before.
+
 1.0.5 Tue May 23 21:24:18 EDT 2017
        - adjust name of distribution to avoid colliding with
          MARC-XML, as PAUSE now enforces distribution name

--- a/marc-xml/MANIFEST
+++ b/marc-xml/MANIFEST
@@ -10,6 +10,8 @@ t/batch-ns.t
 t/batch-ns.xml
 t/batch.t
 t/batch.xml
+t/empty-datafield.t
+t/empty-datafield.xml
 t/empty-record-2.xml
 t/empty-record.t
 t/empty-record.xml
@@ -21,6 +23,8 @@ t/escape.mrc
 t/escape.t
 t/external-entities.t
 t/invalid.xml
+t/missing-indicators.t
+t/missing-indicators.xml
 t/namespace.t
 t/namespace.xml
 t/parser.t

--- a/marc-xml/lib/MARC/File/XML.pm
+++ b/marc-xml/lib/MARC/File/XML.pm
@@ -13,7 +13,7 @@ use IO::File;
 use Carp qw( croak );
 use Encode ();
 
-$VERSION = '1.0.5';
+$VERSION = '1.1.0';
 
 our $parser;
 
@@ -477,15 +477,26 @@ sub decode {
         } elsif ($elt->localname eq 'datafield') {
             my @sfs = ();
             foreach my $sfelt ($elt->getChildrenByLocalName('subfield')) {
-                push @sfs, $sfelt->getAttribute('code'), 
+                push @sfs, $sfelt->getAttribute('code'),
                            $transcode_to_marc8 ? utf8_to_marc8($sfelt->textContent()) : $sfelt->textContent();
             }
-            push @fields, MARC::Field->new(
-                $elt->getAttribute('tag'),
-                $elt->getAttribute('ind1'),
-                $elt->getAttribute('ind2'),
-                @sfs
-            );
+
+            my $tag = $elt->getAttribute('tag');
+
+            unless (@sfs) {
+                $rec->_warn("no subfield data found $location for tag $tag");
+                next;
+            }
+
+            my $ind1 = $elt->getAttribute('ind1');
+            my $ind2 = $elt->getAttribute('ind2');
+            unless (defined $ind1 && defined $ind2) {
+                $rec->_warn("missing indicator(s) forced to blanks $location for tag $tag");
+                $ind1 = ' ' unless defined $ind1;
+                $ind2 = ' ' unless defined $ind2;
+            }
+
+            push @fields, MARC::Field->new($tag, $ind1, $ind2, @sfs);
         }
     }
     $rec->append_fields(@fields);

--- a/marc-xml/t/empty-datafield.t
+++ b/marc-xml/t/empty-datafield.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+use MARC::Record;
+use MARC::File::XML;
+
+open my $IN, '<', 't/empty-datafield.xml';
+my $xml = join('', <$IN>);
+close $IN;
+
+my $r;
+eval { $r = MARC::Record->new_from_xml($xml, 'UTF-8'); };
+ok(!$@, 'new_from_xml() does not die on a <datafield> with no <subfield> children');
+
+ok($r->field('245'), 'the well-formed 245 field survives');
+ok(!$r->field('500'), 'the empty 500 datafield is dropped, not just left blank');
+
+my @warnings = $r->warnings();
+ok(
+    (grep { /500/ } @warnings),
+    'a warning identifying tag 500 is recorded'
+) or diag(join("\n", @warnings));
+
+my $xml_out = $r->as_xml_record();
+unlike($xml_out, qr/tag="500"/, 're-serializing does not resurrect the dropped field');

--- a/marc-xml/t/empty-datafield.xml
+++ b/marc-xml/t/empty-datafield.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+  <leader>00755cam a22002414a 4500</leader>
+  <controlfield tag="001">fol05731351 </controlfield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">ActivePerl with ASP and ADO /</subfield>
+    <subfield code="c">Tobias Martinsson.</subfield>
+  </datafield>
+  <datafield tag="500" ind1=" " ind2=" "></datafield>
+</record>

--- a/marc-xml/t/missing-indicators.t
+++ b/marc-xml/t/missing-indicators.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+use MARC::Record;
+use MARC::File::XML;
+
+open my $IN, '<', 't/missing-indicators.xml';
+my $xml = join('', <$IN>);
+close $IN;
+
+my $r;
+eval { $r = MARC::Record->new_from_xml($xml, 'UTF-8'); };
+ok(!$@, 'new_from_xml() does not die on a <datafield> missing ind1/ind2 entirely');
+
+my $field = $r->field('500');
+ok($field, 'the field with missing indicators is still present');
+is($field->indicator(1), ' ', 'ind1 defaults to a blank');
+is($field->indicator(2), ' ', 'ind2 defaults to a blank');
+
+my @warnings = $r->warnings();
+ok(
+    (grep { /500/ } @warnings),
+    'a warning identifying tag 500 is recorded'
+) or diag(join("\n", @warnings));

--- a/marc-xml/t/missing-indicators.xml
+++ b/marc-xml/t/missing-indicators.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.loc.gov/MARC21/slim">
+  <leader>00755cam a22002414a 4500</leader>
+  <controlfield tag="001">fol05731351 </controlfield>
+  <datafield tag="245" ind1="1" ind2="0">
+    <subfield code="a">ActivePerl with ASP and ADO /</subfield>
+    <subfield code="c">Tobias Martinsson.</subfield>
+  </datafield>
+  <datafield tag="500">
+    <subfield code="a">"Wiley Computer Publishing."</subfield>
+  </datafield>
+</record>


### PR DESCRIPTION
`MARC::File::XML::decode()` unconditionally passed every `<datafield>`'s collected subfields and `ind1`/`ind2` attributes straight into `MARC::Field->new()`, which croaks if there are zero subfields or if either indicator attribute is `undef`. Because the call wasn't guarded, that exception propagated straight out of `new_from_xml()` and aborted the whole record for what is frequently a single stray field.

`MARC::File::USMARC` already treats both of these as recoverable for the binary format: it pre-validates, warns via `$record->_warn()`, and either defaults indicators to blank or drops the field, without dying. This brings `MARC::File::XML::decode()` in line with that:

- A `<datafield>` with no `<subfield>` children is dropped, with a warning identifying the tag — matching USMARC's `"no subfield data found ... for tag ..."` behavior.
- A `<datafield>` missing `ind1`/`ind2` entirely gets them defaulted to `' '`, with a warning. A *present-but-invalid* indicator was already handled leniently by `MARC::Field::new()` itself (it force-blanks and warns); this only covers the attribute being absent.

`record()` (the XML serializer) doesn't duplicate this construction logic, so it needed no change — confirmed there's no second decode path in this file (no SAX-based reader; `MARC::Batch` goes through `decode()`).

**Compatibility**: this is a behavior change. Code relying on `new_from_xml()` throwing to *detect* these two specific cases needs to check `$record->warnings()` on a successful parse instead. Document-level errors (no `<record>` element at all — `t/error-handling.t`) are unaffected and still die. Bumped `1.0.5 -> 1.1.0` and added a `Changes` entry, following this distribution's own precedent for behavior-changing releases (1.0.2's external-entity change).

**Open question**: should this leniency be opt-in (e.g. a `strict`/`liberal` parameter) for at least one release before becoming default behavior, or is matching `MARC::File::USMARC`'s unconditional leniency (no opt-out there either) acceptable as the default straight away? I went with matching USMARC's precedent unconditionally, but wanted to flag the alternative explicitly rather than assume.

Added `t/empty-datafield.t` and `t/missing-indicators.t` (plus fixtures) covering: no death, the good field survives, the bad field/indicators behave as described, a warning is recorded, and — for the empty-datafield case — that re-serializing via `as_xml_record()` doesn't resurrect the dropped field. Ran the full suite; no new failures relative to master.

Fixes #21