### PR TITLE
Add GitHub Actions CI running the full suite on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    name: ${{ matrix.distribution.name }} (perl ${{ matrix.perl }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # A recent stable release and an older one still in common use.
+        # Bump these as new Perls ship; there's nothing special about
+        # either number.
+        perl: ['5.34', '5.40']
+        distribution:
+          - name: marc-record
+            needs: ''
+            build: makemaker
+            cpan_deps: ''
+          - name: marc-charset
+            needs: ''
+            build: makemaker
+            cpan_deps: 'XML::SAX Class::Accessor Unicode::Normalize'
+          - name: marc-lint
+            needs: marc-record
+            build: makemaker
+            cpan_deps: 'Business::ISBN'
+          - name: marc-xml
+            needs: 'marc-record marc-charset'
+            build: makemaker
+            cpan_deps: 'XML::LibXML Test::Warn'
+          - name: marc-marcmaker
+            needs: marc-record
+            build: makemaker
+            cpan_deps: ''
+          - name: marc-mij
+            needs: marc-record
+            build: modulebuild
+            cpan_deps: 'Module::Build JSON ex::monkeypatched'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+
+      - name: Install system dependencies
+        # libxml2-dev is only needed to build XML::LibXML (marc-xml),
+        # but installing it unconditionally keeps this step identical
+        # across every matrix cell.
+        run: sudo apt-get update && sudo apt-get install -y libxml2-dev
+
+      - name: Install CPAN dependencies
+        if: matrix.distribution.cpan_deps != ''
+        run: cpanm --notest ${{ matrix.distribution.cpan_deps }}
+
+      - name: Build sibling distributions this one depends on
+        if: matrix.distribution.needs != ''
+        run: |
+          set -e
+          EXTRA_LIB=""
+          for d in ${{ matrix.distribution.needs }}; do
+            (cd "$d" && perl Makefile.PL && make)
+            EXTRA_LIB="$PWD/$d/blib/lib:$PWD/$d/blib/arch:$EXTRA_LIB"
+          done
+          echo "PERL5LIB=$EXTRA_LIB$PERL5LIB" >> "$GITHUB_ENV"
+
+      # Sibling distributions are built from this checkout, not
+      # installed from CPAN, so a change to e.g. marc-record is
+      # exercised by marc-lint/marc-xml/marc-marcmaker/marc-mij's own
+      # test suites too, not just marc-record's.
+
+      - name: Build and test (ExtUtils::MakeMaker)
+        if: matrix.distribution.build == 'makemaker'
+        working-directory: ${{ matrix.distribution.name }}
+        run: |
+          perl Makefile.PL
+          make
+          make test
+
+      - name: Build and test (Module::Build)
+        if: matrix.distribution.build == 'modulebuild'
+        working-directory: ${{ matrix.distribution.name }}
+        run: |
+          perl Build.PL
+          ./Build
+          ./Build test


### PR DESCRIPTION
No distribution in this repo has any CI today. This adds a GitHub Actions workflow that runs the full test suite on every pull request (and pushes to `master`).

**Design**: a job matrix over `{distribution} x {perl version}` (starting with 5.34 and 5.40 — bump as new Perls ship, nothing special about those two). Since these six distributions live in one repo with real inter-dependencies, each job builds any siblings it needs *from this checkout* — `perl Makefile.PL && make`, then `PERL5LIB` pointed at the resulting `blib/` — rather than installing them from CPAN:

- `marc-lint`, `marc-marcmaker`, `marc-mij` → `marc-record`
- `marc-xml` → `marc-record`, `marc-charset`

That means a PR that changes `marc-record` gets exercised by the dependents' own test suites too, not just `marc-record`'s. Third-party CPAN prereqs (`Business::ISBN`, `XML::LibXML`, `XML::SAX`, `Class::Accessor`, `Unicode::Normalize`, `JSON`, `ex::monkeypatched`, `Module::Build`) are installed explicitly per distribution rather than via `cpanm --installdeps .`, since the latter would also try to fetch `MARC::Record`/`MARC::Charset` from CPAN and shadow the sibling build with a possibly-stale released version.

**Depends on #13**: getting all six distributions green surfaced that `marc-charset` needs `make` (not a bare `prove -l`) to build its character database via `build_db.PL` — the workflow already does this correctly, so that part just works. The one other pre-existing failure, `marc-xml/t/external-entities.t`, is #13/#14's territory: recent `libxml2` stopped calling `MARC::File::XML`'s `ext_ent_handler` for external entities unless `expand_entities` is explicitly set, so the module's intended "die loudly on external entities" behavior currently degrades to silently dropping them instead (confirmed — not a live data-exfiltration risk, `libxml2` itself already refuses to fetch external content by default, but it is a silent behavior regression from what the module intends). #13 fixes this with one line and I've verified it locally: with #13 applied, this workflow is green across all six distributions and all Perl versions in the matrix with no workarounds needed.

Rather than paper over that with a TODO-marked test here, this PR now assumes #13 lands first. Until then, expect `marc-xml`'s job to show one known failing test in this PR's own CI run — that's #13's fix landing, not a problem with this workflow.