### PR TITLE
Document etc/codetables.xml's source and add an opt-in freshness check

### DIFF
--- a/marc-charset/MANIFEST
+++ b/marc-charset/MANIFEST
@@ -41,3 +41,4 @@ t/space.t
 t/table.t
 t/utf8.t
 t/vietnamese.t
+xt/release/codetables-source.t

--- a/marc-charset/build_db.PL
+++ b/marc-charset/build_db.PL
@@ -1,6 +1,11 @@
 use strict;
 use warnings;
 use MARC::Charset::Compiler;
+
+# etc/codetables.xml is vendored from the Library of Congress
+# (https://www.loc.gov/marc/specifications/codetables.xml) with local
+# corrections; see "DATA SOURCE" in MARC::Charset::Compiler's POD
+# before replacing it with a fresh download.
 print "compiling marc8/utf8 database, please be patient\n";
 my $compiler = MARC::Charset::Compiler->new();
 $compiler->compile('etc/codetables.xml');

--- a/marc-charset/lib/MARC/Charset/Compiler.pm
+++ b/marc-charset/lib/MARC/Charset/Compiler.pm
@@ -12,8 +12,30 @@ MARC::Charset::Compiler - compile XML mapping rules from LoC
 =head1 DESCRIPTION
 
 MARC::Charset uses mapping rules from the Library of Congress for
-generating a MARC::Charset::Table for looking up utf8 values based on the 
+generating a MARC::Charset::Table for looking up utf8 values based on the
 source MARC-8 character set and the character.
+
+=head1 DATA SOURCE
+
+The XML mapping files this module compiles (F<etc/codetables.xml>,
+F<etc/additional-iii-characters.xml>, F<etc/cccii.xml> in this
+distribution) originate from the Library of Congress's own published
+character set tables:
+
+    https://www.loc.gov/marc/specifications/codetables.xml
+
+That file is not treated as a live dependency, and this module never
+fetches it at install or run time -- the copy in F<etc/> is vendored
+and versioned with the distribution. It's also known to differ from
+whatever the LC URL currently serves: LC has published more than one
+revision of this file over the years, and the copy here has picked up
+maintainer corrections for at least one known mistake in LC's data
+(see the G0/G1 workaround in C<end_element()> below, for
+characterSet codes 51, 34 and 45). Diffing against the live URL is
+useful context when investigating a specific character mapping, but
+copying it over F<etc/codetables.xml> wholesale is not safe without
+re-checking that those corrections are still needed against whatever
+LC is serving at the time.
 
 =head1 METHODS
 

--- a/marc-charset/xt/release/codetables-source.t
+++ b/marc-charset/xt/release/codetables-source.t
@@ -1,0 +1,58 @@
+#!perl
+#
+# Author/release-only check: is our vendored etc/codetables.xml still
+# the same as what the Library of Congress currently publishes? This
+# is diagnostic, not a build requirement -- MARC::Charset never
+# fetches this URL itself, and a mismatch here is not necessarily a
+# bug. See "DATA SOURCE" in MARC::Charset::Compiler's POD: the
+# vendored copy carries maintainer corrections for known mistakes in
+# LC's own data, so don't just copy a fresh download over
+# etc/codetables.xml without checking those corrections are still
+# needed.
+#
+# Only runs under RELEASE_TESTING, and skips cleanly (rather than
+# failing) if the network, SSL support, or the URL itself isn't
+# available -- most CI and CPAN Testers environments have none of
+# those, and that's fine.
+
+use strict;
+use warnings;
+use Test::More;
+
+unless ($ENV{RELEASE_TESTING}) {
+    plan skip_all => 'set RELEASE_TESTING=1 to run this (network-dependent) check';
+}
+
+eval { require HTTP::Tiny };
+plan skip_all => 'HTTP::Tiny required to check the upstream source' if $@;
+
+my $url = 'https://www.loc.gov/marc/specifications/codetables.xml';
+my $local_file = 'etc/codetables.xml';
+
+my $response = eval { HTTP::Tiny->new(timeout => 15)->get($url) };
+plan skip_all => "couldn't reach $url: $@" if $@;
+plan skip_all => "couldn't reach $url: $response->{status} $response->{reason}"
+    unless $response->{success};
+
+plan tests => 1;
+
+open my $fh, '<:raw', $local_file or die "can't open $local_file: $!";
+local $/;
+my $local_content = <$fh>;
+close $fh;
+
+my $remote_content = $response->{content};
+
+my $ok = ok($local_content eq $remote_content, "$local_file matches $url");
+
+unless ($ok) {
+    diag(sprintf(
+        "%s (%d bytes) differs from the copy currently served at %s (%d bytes).\n" .
+        "This is not automatically a problem -- see \"DATA SOURCE\" in " .
+        "MARC::Charset::Compiler's POD before assuming the local copy is " .
+        "the one that's wrong. To inspect the difference yourself:\n" .
+        "    curl -s %s | diff - %s",
+        $local_file, length($local_content), $url, length($remote_content),
+        $url, $local_file
+    ));
+}


### PR DESCRIPTION
Documents where `marc-charset`'s vendored MARC-8/UCS mapping data comes from — https://www.loc.gov/marc/specifications/codetables.xml — in `MARC::Charset::Compiler`'s POD (new "DATA SOURCE" section) and as a short comment in `build_db.PL`.

I looked into actually syncing from that URL before writing this, and I'd push back on doing that automatically: the live copy is **not** a strict superset of what's vendored here. Diffing the two right now, LC's live file still has a "January 2000" revision of the first table's descriptive notes where the vendored copy has a "December 2007" update — real content drift, not just whitespace. More importantly, `Compiler.pm` already has a documented workaround (`end_element()`, around the G0/G1 handling for charset codes 51/34/45) for a known mistake in LC's own data, which is exactly the kind of local correction that a naive `curl | overwrite` would discard without anyone noticing. So this PR documents the relationship rather than automating it.

What it *does* add: `xt/release/codetables-source.t`, an author-only, `RELEASE_TESTING`-gated test that fetches the current LC copy and diffs it against `etc/codetables.xml`, surfacing drift for a human to look at. It skips cleanly (doesn't fail) if the network, SSL support, or the URL itself isn't reachable — most CI/CPAN Testers environments have none of those. It currently reports a real difference, which is the correct behavior given the drift described above; reconciling that is a separate, deliberate decision, not something this PR does.

Not wired into the main `make test`/CI run — it's genuinely opt-in (`RELEASE_TESTING=1 prove xt/release/`), consistent with how network-dependent author checks are usually handled.