### PR TITLE
Prepare MARC::File::XML 1.0.6 for release

### DIFF
--- a/marc-xml/Changes
+++ b/marc-xml/Changes
@@ -1,5 +1,10 @@
 Revision history for Perl extension MARC-XML
 
+1.0.6 (not yet released)
+       - do not try to read from filehandle that has reached eof()
+         (avoids warning noise; reported by Mark Tompsett) (GH#10)
+       - add tests for end-of-stream handling
+
 1.0.5 Tue May 23 21:24:18 EDT 2017
        - adjust name of distribution to avoid colliding with
          MARC-XML, as PAUSE now enforces distribution name

--- a/marc-xml/lib/MARC/File/XML.pm
+++ b/marc-xml/lib/MARC/File/XML.pm
@@ -13,7 +13,7 @@ use IO::File;
 use Carp qw( croak );
 use Encode ();
 
-$VERSION = '1.0.5';
+$VERSION = '1.0.6';
 
 our $parser;
 


### PR DESCRIPTION
## Summary

CPAN's `MARC::File::XML` has been stuck at 1.0.5 (uploaded May 2017)
even though the `eof()` fix in a56b097 (July 2017) and its
accompanying test have been on `master` unreleased ever since —
that's what #10 is reporting.

This PR just does the mechanical prep so a release is a one-step
`make dist`/upload:
- bump `$VERSION` to 1.0.6 in `lib/MARC/File/XML.pm`
- add a `Changes` entry for the pending fix, following the existing
  changelog style

No functional changes — the fix itself is already merged.

Closes #10

## Test plan
- [x] `prove -l -I../marc-record/lib -I../marc-charset/lib t/` — all
      green except the pre-existing, unrelated `external-entities.t`
      failure (libxml2 2.12+ default entity handling; tracked in #14)
- [x] `t/end-of-stream.t`, which exercises the `eof()` fix, passes